### PR TITLE
Add common misconceptions tag

### DIFF
--- a/markdownParser.test.js
+++ b/markdownParser.test.js
@@ -120,6 +120,15 @@ process.env.MARKDOWN_FILES_PATH.split(" ").forEach(filePath => {
             }
           });
 
+          test(`Has an optional "Common Misconceptions:" tag`, () => {
+            if (stepContent.includes('(Common Misconceptions:')) {
+              const correctAnswerFormat = /\(Common Misconceptions: .+\)/;
+              expect(correctAnswerFormat.test(stepContent)).toBe(true);
+            } else {
+              expect(true).toBe(true); // Pass if no Correct Answer tag is present
+            }
+          });
+
           test(`Has an optional "Support Slide: tag":`, () => {
             if (stepContent.includes('(Support Slide:')) {
               const supportSlideFormat = /\(Support Slide: \d+\)/;
@@ -154,7 +163,7 @@ process.env.MARKDOWN_FILES_PATH.split(" ").forEach(filePath => {
 
             const cleanedTags = potentialTags.map(tag => tag.slice(1, -1) + ':');
 
-            const expectedTags = ['Visual Aid:', 'Correct Answer:', 'Support Slide:', 'Next Slide:', 'Support Question:', 'Write:'];
+            const expectedTags = ['Visual Aid:', 'Correct Answer:', 'Common Misconceptions:', 'Support Slide:', 'Next Slide:', 'Support Question:', 'Write:'];
             
             const unexpectedTags = cleanedTags.filter(tag => !expectedTags.includes(tag.trim()));
 


### PR DESCRIPTION
If the LLM struggles with a specific question, we can add examples of common misconceptions to help it to identify which answer is correct and which answer is wrong