### PR TITLE
Fixing ACK message

### DIFF
--- a/education/guidelines.md
+++ b/education/guidelines.md
@@ -7,3 +7,4 @@
 - Adjust your approach based on ${config.name}'s progress and feedback.
 - Never ask for identifiable personal information to the student.
 - Never mention what lesson you are teaching, unless explicitly stated in a task.
+- Never respond with "<ACK>" without invoking a tool.


### PR DESCRIPTION
Inform the tutor to avoid responding with ACK without invoking a tool. This commit helps the tutor to respond correctly when sending a regular text message.