### PR TITLE
QA: Fix answers for LOs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.env

--- a/education/learning-objectives/1871/17420.md
+++ b/education/learning-objectives/1871/17420.md
@@ -6,7 +6,7 @@ Say: Let us look at the value of different digits and how their positions tell u
 
 ## Step 2
 
-Say: Now can you write and say what the value is of the green counters as a decimal? (Visual Aid: 4 green counters of 1/100 each)(Correct Answer: 0.4)(Support Slide: 3)
+Say: Now can you write and say what the value is of the green counters as a decimal? (Visual Aid: 4 green counters of 1/100 each)(Correct Answer: 0.04)(Support Slide: 3)
 
 ## Step 3
 

--- a/education/learning-objectives/1871/17930.md
+++ b/education/learning-objectives/1871/17930.md
@@ -2,12 +2,12 @@
 
 ## Step 1
 
-Say: Here you can see the same counters shown in a hundreds square.  If we have two tenths, how many strips of ten do we have? (Correct Answer: 2 strips of ten.)
+Say: Here you can see the same counters shown in a hundreds square. If we have two tenths, how many strips of ten do we have? (Correct Answer: 2 strips of ten)(Visual Aid: The slide shows a grid with 2 strips of ten highlighted)
 
 ## Step 2
 
-Say: So we write this as 0.2, showing that we have two groups of ten in the tenths column. If the green counters total is 4 hundredths, how many hundredth squares do I have? (Correct Answer: 4 hundred.)
+Say: So we write this as 0.2, showing that we have two groups of ten in the tenths column. If the green counters total is 4 hundredths, how many hundredth squares do I have? (Correct Answer: 4 hundredths)(Visual Aid: The slide shows a grid with 4 squares highlighted)
 
 ## Step 3
 
-Say: So we write that we have four hundredths in the hundredths column as 0.04. How would you say the the decimal together? (Correct Answer: zero point two four. If the student says zero point twenty-four then explain that we say each place value after the point separately to show how many we have in each position.)
+Say: So we write that we have four hundredths in the hundredths column as 0.04. How would you say the the decimal together? (Correct Answer: zero point two four. If the student says zero point twenty-four then explain that we say each place value after the point separately to show how many we have in each position)(Visual Aid: The slide shows 2 counters of 1/10 and 4 counters of 1/100)

--- a/education/learning-objectives/1920/17987.md
+++ b/education/learning-objectives/1920/17987.md
@@ -6,7 +6,7 @@ Say: We are going to do practice now, doing one question at a time. What is the 
 
 ## Step 2
 
-Say: Now for question b, what is the decimal when you subtract 0.8? (Correct Answer: 3.08) (Visual Aid: 3.87 - 0.8)
+Say: Now for question b, what is the decimal when you subtract 0.8? (Correct Answer: 3.07) (Visual Aid: 3.87 - 0.8)
 
 ## Step 3
 

--- a/education/learning-objectives/1921/17989.md
+++ b/education/learning-objectives/1921/17989.md
@@ -2,8 +2,8 @@
 
 ## Step 1
 
-Say: We are going to learn about partitioning decimal numbers in this lesson. Before we start, lets check what you understand already. Could you fill in the missing number in the part-whole number for the learning goal question.(Correct Answer: 0.05)(Next slide: 7)
+Say: We are going to learn about partitioning decimal numbers in this lesson. Before we start, lets check what you understand already. Could you fill in the missing number in the part-whole number for the learning goal question.(Correct Answer: 0.05)(Visual Aid: The slide shows 2.45 = 2.4 + x)(Next Slide: 7)
 
 ## Step 2
 
-Say: For the prior learning question, what number is missing to complete the sentence. (Correct Answer: 4,000)(Next Slide: 3) (Support Slide: 2)
+Say: For the prior learning question, what number is missing to complete the sentence. (Correct Answer: 4,000)(Visual Aid: The slide shows 300,000 + 60,000 + x + 70 + 1 = 364,071)(Next Slide: 3)(Support Slide: 2)

--- a/education/learning-objectives/1921/17996.md
+++ b/education/learning-objectives/1921/17996.md
@@ -2,4 +2,4 @@
 
 ## Step 1
 
-Say: Let's take the number 53.42 and explore four ways to represent it. The Gattengo Chart highlights each part of the number. The counters represent each column's value. The Place Value Chart displays the number in place value columns while method 4 shows each part in words. Which method do think is the easiest to understand how big the number is? (Correct Answer: Any answer that makes sense)(Next Slide:5)
+Say: Let's take the number 53.42 and explore four ways to represent it. The Gattengo Chart highlights each part of the number. The counters represent each column's value. The Place Value Chart displays the number in place value columns while method 4 shows each part in words. Which method do think is the easiest to understand how big the number is? (Correct Answer: Any answer that makes sense)(Next Slide: 5)

--- a/education/learning-objectives/1966/18428.md
+++ b/education/learning-objectives/1966/18428.md
@@ -6,20 +6,20 @@ Say: In our lessons, we will try to get you speaking, reasoning and explaining o
 
 ## Step 2
 
-Say: Can you tell me how many thousand counters are missing? (Correct Answer: 4)(Visual Aid: The number five thousand, four hundred and sixty-three represented in counters but with some counters ripped out)
+Say: Can you tell me how many thousand counters are missing? (Correct Answer: 4)(Visual Aid: The number five thousand, four hundred and sixty-three represented in place value counters, but with some counters ripped out. The visible counters include one "1,000" counter, two "100" counters, three "10" counters, and two "1" counters.)
 
 ## Step 3
 
-Say: Now how many hundereds are missing? (Correct Answer: 2)
+Say: Now how many hundreds are missing? (Correct Answer: 2)(Visual Aid: The number five thousand, four hundred and sixty-three represented in place value counters, but with some counters ripped out. The visible counters include one "1,000" counter, two "100" counters, three "10" counters, and two "1" counters.)
 
 ## Step 4
 
-Say: What should we do next? (Correct Answer: Check how many ten counters are missing)
+Say: What should we do next? (Correct Answer: Check how many ten counters are missing)(Visual Aid: The number five thousand, four hundred and sixty-three represented in place value counters, but with some counters ripped out. The visible counters include one "1,000" counter, two "100" counters, three "10" counters, and two "1" counters. The student has already identified the missing thousands and hundreds place value counters)
 
 ## Step 5
 
-Say: So how many tens counters are missing then? (Correct Answer: 3)
+Say: So how many tens counters are missing then? (Correct Answer: 3)(Visual Aid: The number five thousand, four hundred and sixty-three represented in place value counters, but with some counters ripped out. The visible counters include one "1,000" counter, two "100" counters, three "10" counters, and two "1" counters.)
 
 ## Step 6
 
-Say: So what is the final step and what is the answer? (Correct Answer: Check how ones are missing and there is one missing)
+Say: So what is the final step and what is the answer? (Correct Answer: Check how ones are missing and there is one missing)(Visual Aid: The number five thousand, four hundred and sixty-three represented in place value counters, but with some counters ripped out. The visible counters include one "1,000" counter, two "100" counters, three "10" counters, and two "1" counters.)


### PR DESCRIPTION
This commit includes a few fixes for LO 1966, 1871, 1920 and 1921

Generally speaking we have the following type of errors:

- Typos, where the answer provided in not correct
- Missing visual aid, where the question is not stated in the utterance and the visual aid is not provided
- Incomplete visual aid, where the visual aid is provided, but it's not enough for the llm to understand the question