### PR TITLE
IMPROVEMENT: Add followup question for ongoing sessions

### DIFF
--- a/education/ongoing_sessions_with_skye.md
+++ b/education/ongoing_sessions_with_skye.md
@@ -8,7 +8,7 @@ Greet ${config.name} warmly and engage them using only one of these randomly cho
     - Find out their favorite subject and why.
     - Encourage them to share a recent learning or question.
 
-Wait for the student to reply, then use the **jumpToSlide** tool with index ${config.programme.firstSlide}. Include:
+Ask the student one follow up question about their response. Wait for the student to reply. After the student replies, inform the student that its time to start their maths lesson and use the **jumpToSlide** tool with index ${config.programme.firstSlide}. Include:
     - Your response to their last message.
     - Any relevant reminders.
     - Brief recap of previous session report, if present.


### PR DESCRIPTION
This prompt change instructs the tutor to ask a follow-up question at the very beginning of the session.